### PR TITLE
Using fetch for tables in odbc adapter

### DIFF
--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -13,7 +13,7 @@ module ODBCAdapter
     # current connection.
     def tables(_name = nil)
       stmt   = @connection.tables
-      result = stmt.fetch_all || []
+      result = stmt.fetch || []
       stmt.drop
 
       result.each_with_object([]) do |row, table_names|


### PR DESCRIPTION
Using `fetch` for tables in odbc adapter