### PR TITLE
Gemspec and release should have the same version number

### DIFF
--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ODBCAdapter
-  VERSION = '5.0.6'
+  VERSION = '6.1.3'
 end


### PR DESCRIPTION
I'm not sure what your next release version is but I wanted to point out that it's necessary to bump this constant for RubyGems and Bundle compatibility with your versioning scheme (and I didn't see a way to submit an issue). So I've set the version to 6.1.3 for now.